### PR TITLE
Added resize_mode to Sprite initializations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ impl FlockingPlugin {
                 }),
                 translation: Translation::new(0.0, 0.0, 0.0),
                 sprite: Sprite {
-                    size: Vec2::new(window.width as f32, window.height as f32)
+                    size: Vec2::new(window.width as f32, window.height as f32),
+                    resize_mode: SpriteResizeMode::Automatic,
                 },
                 ..Default::default()
             });
@@ -200,7 +201,8 @@ impl FlockingPlugin {
                             id as f32
                         ),
                         sprite: Sprite {
-                            size: Vec2::new(8.0, 8.0)
+                            size: Vec2::new(8.0, 8.0),
+                            resize_mode: SpriteResizeMode::Automatic,
                         },
                         ..Default::default()
                     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ impl FlockingPlugin {
                 translation: Translation::new(0.0, 0.0, 0.0),
                 sprite: Sprite {
                     size: Vec2::new(window.width as f32, window.height as f32),
-                    resize_mode: SpriteResizeMode::Automatic,
+                    ..Default::default()
                 },
                 ..Default::default()
             });


### PR DESCRIPTION
The repo currently does not compile.  It appears bevy changed the API for creating sprite structs.  This pull request updates the code to match the new API